### PR TITLE
Fix ImagePlayground integration and availability annotations

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -12,7 +12,6 @@ import CoreImage
 import UIKit
 #endif
 #if os(iOS) && canImport(ImagePlayground)
-@available(iOS 18.0, *)
 import ImagePlayground
 #endif
 

--- a/app/FastVLM App/ImageGenerator.swift
+++ b/app/FastVLM App/ImageGenerator.swift
@@ -7,31 +7,34 @@ import Foundation
 #if os(iOS)
 import UIKit
 #if canImport(ImagePlayground)
-@available(iOS 18.4, *)
 import ImagePlayground
 
 /// Wrapper around Image Playground to generate images in the background.
 @MainActor
 @available(iOS 18.0, *)
 class PlaygroundImageGenerator {
-    private let session: PlaygroundSession?
+    private var creator: ImageCreator?
 
-    init() {
-        session = try? PlaygroundSession()
-    }
+    init() {}
 
     /// Generate a new image based on the provided one using Image Playground.
     /// - Parameter image: Source image.
     /// - Returns: Generated image or nil if generation fails.
     func generate(from image: UIImage) async -> UIImage? {
-        guard let session else { return nil }
         do {
-            let request = PlaygroundImageRequest(referenceImage: image)
-            let result = try await session.image(from: request)
-            return result
+            if creator == nil {
+                creator = try await ImageCreator()
+            }
+            guard let creator, let cgImage = image.cgImage else { return nil }
+            let concepts: [ImagePlaygroundConcept] = [.image(cgImage)]
+            let images = creator.images(for: concepts, style: .sketch, limit: 1)
+            for try await result in images {
+                return UIImage(cgImage: result.cgImage)
+            }
         } catch {
             return nil
         }
+        return nil
     }
 }
 #else


### PR DESCRIPTION
## Summary
- Remove incorrect `@available` attributes on import statements
- Use `ImageCreator` API for Image Playground image generation

## Testing
- `pytest -q` *(fails: No module named 'torch')*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2ee158c832ab2b45a8a1677301e