### PR TITLE
Start camera session on app launch

### DIFF
--- a/app/FastVLM App/ContentView.swift
+++ b/app/FastVLM App/ContentView.swift
@@ -183,6 +183,10 @@ struct ContentView: View {
             camera.attach(continuation: $0)
         }
 
+        // Ensure the camera capture session is running before we begin
+        // distributing frames so the preview is available immediately.
+        camera.start()
+
         let (framesToDisplay, displayCont) = AsyncStream.makeStream(
             of: CVImageBuffer.self,
             bufferingPolicy: .bufferingNewest(1)
@@ -210,6 +214,7 @@ struct ContentView: View {
         await MainActor.run {
             self.framesToDisplay = nil
             self.camera.detatch()
+            self.camera.stop()
         }
 
         displayCont.finish()


### PR DESCRIPTION
## Summary
- start camera capture session when distributing video frames to avoid blank preview
- stop camera session when tearing down

## Testing
- `swiftc app/'FastVLM App'/ContentView.swift -o /tmp/test` *(fails: no such module 'AVFoundation')*

------
https://chatgpt.com/codex/tasks/task_e_689df16feb34832ab751efe13e82705a