### PR TITLE
Add first-run model download screen

### DIFF
--- a/app/GenAICam.xcodeproj/project.pbxproj
+++ b/app/GenAICam.xcodeproj/project.pbxproj
@@ -20,7 +20,8 @@
 		C3ED54582D790A68005E20B3 /* MLXFast in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED54572D790A68005E20B3 /* MLXFast */; };
 		C3ED545B2D790AD6005E20B3 /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = C3ED545A2D790AD6005E20B3 /* Transformers */; };
 		C3ED55012D7A0A7A005E20B3 /* FastVLM.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C39BB3E62D79082A005DB8FB /* FastVLM.framework */; };
-		C3ED55022D7A0A7A005E20B3 /* FastVLM.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C39BB3E62D79082A005DB8FB /* FastVLM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+                C3ED55022D7A0A7A005E20B3 /* FastVLM.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C39BB3E62D79082A005DB8FB /* FastVLM.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+                C3F4ABCC2D8E0F50005E20B3 /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = C3F4ABCB2D8E0F50005E20B3 /* ZIPFoundation */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,14 +124,15 @@
 		019A3E072D78E6A00055F93B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-			files = (
-				019A3E1C2D78E73E0055F93B /* MLXLMCommon in Frameworks */,
-				019A3E212D78E7530055F93B /* Video.framework in Frameworks */,
-				C3ED55012D7A0A7A005E20B3 /* FastVLM.framework in Frameworks */,
-				019A3E1E2D78E7470055F93B /* MLXRandom in Frameworks */,
-				019A3E202D78E74C0055F93B /* MLXVLM in Frameworks */,
-				019A3E1A2D78E7370055F93B /* MLX in Frameworks */,
-			);
+                        files = (
+                                019A3E1C2D78E73E0055F93B /* MLXLMCommon in Frameworks */,
+                                019A3E212D78E7530055F93B /* Video.framework in Frameworks */,
+                                C3ED55012D7A0A7A005E20B3 /* FastVLM.framework in Frameworks */,
+                                019A3E1E2D78E7470055F93B /* MLXRandom in Frameworks */,
+                                019A3E202D78E74C0055F93B /* MLXVLM in Frameworks */,
+                                019A3E1A2D78E7370055F93B /* MLX in Frameworks */,
+                                C3F4ABCC2D8E0F50005E20B3 /* ZIPFoundation in Frameworks */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C35372AB2D08C32D00474D34 /* Frameworks */ = {
@@ -226,12 +228,13 @@
 				019A3E0B2D78E6A00055F93B /* GenAICam */,
 			);
 			name = GenAICam;
-			packageProductDependencies = (
-				019A3E192D78E7370055F93B /* MLX */,
-				019A3E1B2D78E73E0055F93B /* MLXLMCommon */,
-				019A3E1D2D78E7470055F93B /* MLXRandom */,
-				019A3E1F2D78E74C0055F93B /* MLXVLM */,
-			);
+                        packageProductDependencies = (
+                                019A3E192D78E7370055F93B /* MLX */,
+                                019A3E1B2D78E73E0055F93B /* MLXLMCommon */,
+                                019A3E1D2D78E7470055F93B /* MLXRandom */,
+                                019A3E1F2D78E74C0055F93B /* MLXVLM */,
+                                C3F4ABCB2D8E0F50005E20B3 /* ZIPFoundation */,
+                        );
 			productName = GenAICam;
 			productReference = 019A3E0A2D78E6A00055F93B /* GenAICam.app */;
 			productType = "com.apple.product-type.application";
@@ -319,11 +322,12 @@
 			);
 			mainGroup = C35EDB632D07699400757E80;
 			minimizedProjectReferenceProxies = 1;
-			packageReferences = (
-				C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
-				C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */,
-				C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */,
-			);
+                        packageReferences = (
+                                C35EDB6A2D076A3900757E80 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
+                                C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */,
+                                C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+                                C3F4ABCA2D8E0F50005E20B3 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
+                        );
 			preferredProjectObjectVersion = 77;
 			productRefGroup = C35EDB702D076A5A00757E80 /* Products */;
 			projectDirPath = "";
@@ -488,7 +492,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.ml.GenAICam;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.GenAICam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
@@ -586,7 +590,7 @@
 				MARKETING_VERSION = 1.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.ml.GenAICam;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.GenAICam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = auto;
@@ -954,7 +958,7 @@
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.ml.FastVLM;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.FastVLM;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -1049,7 +1053,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.ml.FastVLM;
+				PRODUCT_BUNDLE_IDENTIFIER = cc.pizzato.FastVLM;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
@@ -1124,14 +1128,22 @@
 				minimumVersion = 0.21.2;
 			};
 		};
-		C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/huggingface/swift-transformers";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.18;
-			};
-		};
+                C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */ = {
+                        isa = XCRemoteSwiftPackageReference;
+                        repositoryURL = "https://github.com/huggingface/swift-transformers";
+                        requirement = {
+                                kind = upToNextMajorVersion;
+                                minimumVersion = 0.1.18;
+                        };
+                };
+                C3F4ABCA2D8E0F50005E20B3 /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
+                        isa = XCRemoteSwiftPackageReference;
+                        repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
+                        requirement = {
+                                kind = upToNextMajorVersion;
+                                minimumVersion = 0.9.19;
+                        };
+                };
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1180,11 +1192,16 @@
 			package = C35EDB8A2D07777E00757E80 /* XCRemoteSwiftPackageReference "mlx-swift" */;
 			productName = MLXFast;
 		};
-		C3ED545A2D790AD6005E20B3 /* Transformers */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
-			productName = Transformers;
-		};
+                C3ED545A2D790AD6005E20B3 /* Transformers */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        package = C3ED54592D790AC6005E20B3 /* XCRemoteSwiftPackageReference "swift-transformers" */;
+                        productName = Transformers;
+                };
+                C3F4ABCB2D8E0F50005E20B3 /* ZIPFoundation */ = {
+                        isa = XCSwiftPackageProductDependency;
+                        package = C3F4ABCA2D8E0F50005E20B3 /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+                        productName = ZIPFoundation;
+                };
 /* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = C35EDB642D07699400757E80 /* Project object */;

--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -37,7 +37,7 @@ let longPromptSuffix = "Long and detailed description please."
 
 struct ContentView: View {
     @State private var camera = CameraController()
-    @State private var model = FastVLMModel()
+    @StateObject private var model = FastVLMModel()
 
     /// stream of frames -> VideoFrameView, see distributeVideoFrames
     @State private var framesToDisplay: AsyncStream<CVImageBuffer>?

--- a/app/GenAICam/GenAICamApp.swift
+++ b/app/GenAICam/GenAICamApp.swift
@@ -7,9 +7,15 @@ import SwiftUI
 
 @main
 struct GenAICamApp: App {
+    @State private var needsModelDownload = !FastVLMModel.modelExists()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if needsModelDownload {
+                ModelDownloadView(needsModelDownload: $needsModelDownload)
+            } else {
+                ContentView()
+            }
         }
     }
 }

--- a/app/GenAICam/ModelDownloadView.swift
+++ b/app/GenAICam/ModelDownloadView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct ModelDownloadView: View {
+    @Binding var needsModelDownload: Bool
+    @StateObject private var model = FastVLMModel()
+    @State private var isDownloading = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("On first run, we need to download Apple's FastVLM model, this is the only time the internet has to be accessed. The model is slightly above 1GB, make sure you use WiFi")
+                .multilineTextAlignment(.center)
+                .padding()
+            if isDownloading {
+                if let progress = model.downloadProgress {
+                    ProgressView(value: progress, total: 1.0)
+                        .progressViewStyle(.linear)
+                        .padding()
+                } else {
+                    ProgressView()
+                        .progressViewStyle(.linear)
+                        .padding()
+                }
+                Text(model.modelInfo)
+            } else {
+                Text(model.modelInfo)
+                Button("Download Model") {
+                    isDownloading = true
+                    Task {
+                        let success = await model.download()
+                        if success {
+                            needsModelDownload = false
+                        } else {
+                            isDownloading = false
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ModelDownloadView(needsModelDownload: .constant(true))
+}

--- a/app/README.md
+++ b/app/README.md
@@ -78,25 +78,13 @@ There are 3 pretrained sizes of FastVLM to choose from:
 
 To download any FastVLM listed above, use the [get_pretrained_mlx_model.sh](get_pretrained_mlx_model.sh) script. The script downloads the model from the web and places it in the appropriate location. Once a model has been downloaded using the steps below, no additional steps are needed to build the app in Xcode.
 
-To explore how the other models work for your use-case, simply re-run the `get_pretrained_mlx_model.sh` with the new model selected, follow the prompts, and rebuild your app in Xcode.
+To explore how the other models work for your use-case, simply re-run the `get_pretrained_mlx_model.sh` with the new model selected, follow the prompts, and rebuild your app in Xcode. This step is optional as the app will now download the default model on its first launch.
 
-### Download Instructions
+### Model Download
 
-1. Make the script executable
-
-```shell
-chmod +x app/get_pretrained_mlx_model.sh
-```
-
-2. Download FastVLM
-
-```shell
-app/get_pretrained_mlx_model.sh --model 0.5b --dest app/FastVLM/model
-```
-
-3. Open the app in Xcode, Build, and Run.
+The FastVLM weights are no longer bundled with the project. On first launch the app shows a screen explaining that Apple’s FastVLM model (slightly above 1 GB) must be fetched once over the internet. After tapping **Download Model**, a progress bar tracks the download and the archive is cached in the application support directory so subsequent runs work fully offline.
 
 ### Custom Model
 
 In addition to pretrained sizes of FastVLM, you can further quantize or fine-tune FastVLM to best fit their needs. To learn more, check out our documentation on how to [`export the model`](../model_export#export-vlm).
-Please clear existing model in `app/FastVLM/model` before downloading or copying a new model. 
+If you download a different model size, delete the cached files in the application support directory before running the app again.


### PR DESCRIPTION
## Summary
- Add progress-tracked FastVLM model download helper and presence check
- Introduce first-run download screen with progress bar and status text
- Gate app launch on model presence and document flow
- Fix FastVLM model download delegate conformance to avoid build errors
- Require successful model download before launching main app and reset view on failure
- Download and extract the 0.5B FastVLM weights at runtime, mirroring the `get_pretrained_mlx_model.sh` flow
- Log model download and extraction progress to the console and depend on ZIPFoundation for in-app unzipping
- Convert model loader to `ObservableObject` and surface download status in the first-run screen
- Show animated progress bar while downloading/extracting and hide the Download button once tapped

## Testing
- `pytest`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68aefe266500832a8798075d334ccd7a