### PR TITLE
Add stable diffusion image generation option

### DIFF
--- a/app/GenAICam/GenAICamApp.swift
+++ b/app/GenAICam/GenAICamApp.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 @main
 struct GenAICamApp: App {
-    @State private var needsModelDownload = !FastVLMModel.modelExists()
+    @State private var needsModelDownload = !(FastVLMModel.modelExists() && StableDiffusionGenerator.modelExists())
 
     var body: some Scene {
         WindowGroup {

--- a/app/GenAICam/ImageGenerator.swift
+++ b/app/GenAICam/ImageGenerator.swift
@@ -18,6 +18,31 @@ enum PlaygroundStyle: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 }
 
+/// Modes for image generation.
+enum ImageGeneratorMode: String, CaseIterable, Identifiable {
+    case stableDiffusion
+    case imagePlayground
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+        case .stableDiffusion: return "Stable Diffusion"
+        case .imagePlayground: return "Image Playground"
+        }
+    }
+}
+
+/// Option selected when requesting a new image.
+enum GenerationOption: Identifiable {
+    case stableDiffusion
+    case playground(PlaygroundStyle)
+    var id: String {
+        switch self {
+        case .stableDiffusion: return "stableDiffusion"
+        case .playground(let style): return "playground-\(style.rawValue)"
+        }
+    }
+}
+
 #if canImport(ImagePlayground)
 /// Wrapper around Image Playground to generate images in the background.
 @MainActor

--- a/app/GenAICam/ModelDownloadView.swift
+++ b/app/GenAICam/ModelDownloadView.swift
@@ -3,31 +3,48 @@ import SwiftUI
 struct ModelDownloadView: View {
     @Binding var needsModelDownload: Bool
     @StateObject private var model = FastVLMModel()
+    @StateObject private var sdModel = StableDiffusionGenerator()
     @State private var isDownloading = false
 
     var body: some View {
         VStack(spacing: 20) {
-            Text("On this first run, press Download to get Apple’s FastVLM model (~1.1 GB). This one-time setup enables offline image descriptions and is the only time the app needs internet. Please use Wi-Fi.")
+            Text("On this first run, press Download to get Apple’s FastVLM model (~1.1 GB) and the Stable Diffusion model. This one-time setup enables offline features and is the only time the app needs internet. Please use Wi-Fi.")
                 .multilineTextAlignment(.center)
                 .padding()
             if isDownloading {
-                if let progress = model.downloadProgress {
-                    ProgressView(value: progress, total: 1.0)
-                        .progressViewStyle(.linear)
-                        .padding()
-                } else {
-                    ProgressView()
-                        .progressViewStyle(.linear)
-                        .padding()
+                VStack {
+                    if let progress = model.downloadProgress {
+                        ProgressView(value: progress, total: 1.0)
+                            .progressViewStyle(.linear)
+                            .padding()
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.linear)
+                            .padding()
+                    }
+                    Text(model.modelInfo)
+                    if let progress = sdModel.downloadProgress {
+                        ProgressView(value: progress, total: 1.0)
+                            .progressViewStyle(.linear)
+                            .padding()
+                    } else {
+                        ProgressView()
+                            .progressViewStyle(.linear)
+                            .padding()
+                    }
+                    Text(sdModel.status)
                 }
-                Text(model.modelInfo)
             } else {
-                Text(model.modelInfo)
-                Button("Download Model") {
+                VStack {
+                    Text(model.modelInfo)
+                    Text(sdModel.status)
+                }
+                Button("Download Models") {
                     isDownloading = true
                     Task {
-                        let success = await model.download()
-                        if success {
+                        let successVLM = await model.download()
+                        let successSD = await sdModel.downloadModel()
+                        if successVLM && successSD {
                             needsModelDownload = false
                         } else {
                             isDownloading = false

--- a/app/GenAICam/PhotoPreviewView.swift
+++ b/app/GenAICam/PhotoPreviewView.swift
@@ -12,10 +12,11 @@ struct PhotoPreviewView: View {
     let image: UIImage
     @Binding var generatedImage: UIImage?
     @Binding var description: String
+    @Binding var generationStatus: String
     let shortDescription: String
     let longDescription: String
     var onRetake: () -> Void
-    var onRecreate: (PlaygroundStyle?) -> Void
+    var onRecreate: (GenerationOption?) -> Void
 
     @State private var showShare = false
     @State private var showMore = false
@@ -94,9 +95,10 @@ struct PhotoPreviewView: View {
                             )
                         }
                         .contextMenu {
+                            Button("Stable Diffusion") { onRecreate(.stableDiffusion) }
                             ForEach(PlaygroundStyle.allCases) { option in
-                                Button(option.rawValue.capitalized) {
-                                    onRecreate(option)
+                                Button("Playground: \(option.rawValue.capitalized)") {
+                                    onRecreate(.playground(option))
                                 }
                             }
                         }
@@ -132,7 +134,12 @@ struct PhotoPreviewView: View {
                             Text("Generating image")
                                 .font(.headline)
                                 .foregroundColor(.white)
-                            if !description.isEmpty {
+                            if !generationStatus.isEmpty {
+                                Text(generationStatus)
+                                    .font(.subheadline)
+                                    .foregroundColor(.white)
+                                    .multilineTextAlignment(.center)
+                            } else if !description.isEmpty {
                                 Text(description)
                                     .font(.subheadline)
                                     .foregroundColor(.white)

--- a/app/GenAICam/SettingsView.swift
+++ b/app/GenAICam/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @Binding var mode: DescriptionMode
     @Binding var isRealTime: Bool
     @Binding var showDescription: Bool
+    @Binding var generatorMode: ImageGeneratorMode
     @State private var showWelcome = false
     
     private var appName: String {
@@ -31,6 +32,15 @@ struct SettingsView: View {
                     Picker("Type", selection: $mode) {
                         Text("Short").tag(DescriptionMode.short)
                         Text("Long").tag(DescriptionMode.long)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("Generator") {
+                    Picker("Type", selection: $generatorMode) {
+                        ForEach(ImageGeneratorMode.allCases) { option in
+                            Text(option.title).tag(option)
+                        }
                     }
                     .pickerStyle(.segmented)
                 }
@@ -60,5 +70,5 @@ struct SettingsView: View {
 }
 
 #Preview {
-    SettingsView(style: .constant(.sketch), mode: .constant(.short), isRealTime: .constant(false), showDescription: .constant(false))
+    SettingsView(style: .constant(.sketch), mode: .constant(.short), isRealTime: .constant(false), showDescription: .constant(false), generatorMode: .constant(.stableDiffusion))
 }

--- a/app/GenAICam/StableDiffusionGenerator.swift
+++ b/app/GenAICam/StableDiffusionGenerator.swift
@@ -1,0 +1,147 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import Foundation
+import SwiftUI
+import CoreML
+#if canImport(StableDiffusion)
+import StableDiffusion
+#endif
+#if canImport(ZIPFoundation)
+import ZIPFoundation
+#endif
+
+/// Wrapper around a Core ML Stable Diffusion pipeline.
+@MainActor
+class StableDiffusionGenerator: ObservableObject {
+    @Published var downloadProgress: Double? = nil
+    @Published var status: String = ""
+
+    private let modelDirectory: URL = {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        return support.appendingPathComponent("StableDiffusion/model", isDirectory: true)
+    }()
+
+    private let modelArchiveURL = URL(string: "https://huggingface.co/apple/coreml-stable-diffusion-2-1-base-palettized/resolve/main/coreml-stable-diffusion-2-1-base-palettized_split_einsum_v2_compiled.zip")!
+
+    /// Returns true if the model resources are already available on disk.
+    static func modelExists() -> Bool {
+        let support = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let config = support.appendingPathComponent("StableDiffusion/model")
+        return FileManager.default.fileExists(atPath: config.path)
+    }
+
+    /// Downloads and unpacks the Stable Diffusion resources if needed.
+    func downloadModel() async -> Bool {
+        let fm = FileManager.default
+        let modelPath = modelDirectory.path
+        if fm.fileExists(atPath: modelPath) {
+            status = "Model ready"
+            downloadProgress = 1.0
+            return true
+        }
+
+        status = "Downloading..."
+        downloadProgress = 0
+
+        do {
+            try fm.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+            let tempDir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? fm.removeItem(at: tempDir) }
+
+            let zipURL = tempDir.appendingPathComponent("model.zip")
+            let downloader = DownloadDelegate()
+            try await downloader.download(from: modelArchiveURL, to: zipURL) { received, expected in
+                let progress = expected > 0 ? Double(received) / Double(expected) : nil
+                Task { @MainActor in
+                    if let progress { self.downloadProgress = progress; self.status = String(format: "Downloading %d%%", Int(progress * 100)) }
+                }
+            }
+
+            #if canImport(ZIPFoundation)
+            try fm.unzipItem(at: zipURL, to: modelDirectory)
+            #endif
+
+            await MainActor.run {
+                self.status = "Download complete"
+                self.downloadProgress = 1.0
+            }
+            return true
+        } catch {
+            await MainActor.run {
+                self.status = "Download failed"
+                self.downloadProgress = nil
+            }
+            return false
+        }
+    }
+
+    /// Generates an image for the given text prompt.
+    /// - Parameters:
+    ///   - prompt: Text prompt describing the desired image.
+    ///   - progress: Called with the current step and total step count.
+    /// - Returns: Generated image or nil on failure.
+    func generate(prompt: String, progress: @escaping (Int, Int) -> Void) async -> UIImage? {
+        #if canImport(StableDiffusion)
+        do {
+            let resourcesURL = modelDirectory
+            let pipeline = try StableDiffusionPipeline(resourcesAt: resourcesURL)
+            pipeline.progressHandler = { step, stepCount in
+                progress(step + 1, stepCount)
+                return true
+            }
+            let images = try pipeline.generate(prompt: prompt, stepCount: 20, seed: UInt32.random(in: 0..<UInt32.max))
+            return images.first
+        } catch {
+            return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+}
+
+private final class DownloadDelegate: NSObject, URLSessionDownloadDelegate {
+    var progressHandler: ((Int64, Int64) -> Void)?
+    var destinationURL: URL?
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var session: URLSession?
+
+    func download(from url: URL, to destinationURL: URL, progress: @escaping (Int64, Int64) -> Void) async throws {
+        self.destinationURL = destinationURL
+        self.progressHandler = progress
+        let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        self.session = session
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.continuation = continuation
+            session.downloadTask(with: url).resume()
+        }
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        progressHandler?(totalBytesWritten, totalBytesExpectedToWrite)
+    }
+
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        do {
+            if let dest = destinationURL {
+                let fm = FileManager.default
+                if fm.fileExists(atPath: dest.path) {
+                    try fm.removeItem(at: dest)
+                }
+                try fm.moveItem(at: location, to: dest)
+            }
+            continuation?.resume(returning: ())
+        } catch {
+            continuation?.resume(throwing: error)
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error { continuation?.resume(throwing: error) }
+        session.invalidateAndCancel()
+    }
+}


### PR DESCRIPTION
## Summary
- download and integrate Core ML Stable Diffusion model with progress updates
- allow choosing between Stable Diffusion and Image Playground in settings and recreate menu
- show step-based generation status during image creation

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68b42fac7450832a9e6ca95c6544a388