### PR TITLE
Warn when Image Playground unavailable

### DIFF
--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -69,6 +69,7 @@ struct ContentView: View {
     @State private var showWelcome: Bool = false
     @State private var previousOutput: String = ""
     @State private var diffedOutput: AttributedString = ""
+    @State private var showPlaygroundWarning = false
 
     var body: some View {
         ZStack {
@@ -184,6 +185,9 @@ struct ContentView: View {
         .task {
             await distributeVideoFrames()
         }
+        .task {
+            await checkPlaygroundAvailability()
+        }
         .onAppear {
             if !hasSeenWelcome {
                 showWelcome = true
@@ -225,6 +229,16 @@ struct ContentView: View {
                 mode: $descriptionMode,
                 isRealTime: $isRealTime,
                 showDescription: $showDescription
+            )
+        }
+        .alert(
+            "Image Playground Unavailable",
+            isPresented: $showPlaygroundWarning
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(
+                "Apple Image Playground is not installed or enabled. Image generation on device will not work; only image descriptions will be available."
             )
         }
         .onChange(of: isRealTime) { _, newValue in
@@ -369,6 +383,24 @@ struct ContentView: View {
                 )
             }
         }
+#endif
+    }
+
+    @MainActor
+    func checkPlaygroundAvailability() async {
+#if os(iOS)
+#if canImport(ImagePlayground)
+        if #available(iOS 18.0, *) {
+            let available = await imageGenerator.isImagePlaygroundAvailable()
+            if !available {
+                showPlaygroundWarning = true
+            }
+        } else {
+            showPlaygroundWarning = true
+        }
+#else
+        showPlaygroundWarning = true
+#endif
 #endif
     }
 


### PR DESCRIPTION
## Summary
- Add runtime check for Apple Image Playground availability in `PlaygroundImageGenerator`.
- Trigger check on app launch and alert user when Image Playground is missing or disabled.

## Testing
- `swift --version`
- `python -m py_compile predict.py`
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e37424b8832a9cd0f9b564e0a214