### PR TITLE
Reduce Stable Diffusion memory usage on low-memory devices

### DIFF
--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
     @AppStorage("stableDiffusionGuidance") private var stableDiffusionGuidance: Double = StableDiffusionGuidancePreset.standard.rawValue
     @AppStorage("stableDiffusionPromptSuffix") private var stableDiffusionPromptSuffix: String = "photo, high quality, 8k"
     @StateObject private var stableDiffusionGenerator = StableDiffusionGenerator()
-    private nonisolated(unsafe) static let stableDiffusionLoadingMessage = "Loading Stable Diffusion pipeline. This may take a minute or so..."
+    private static let stableDiffusionLoadingMessage = "Loading Stable Diffusion pipeline. This may take a minute or so..."
     @AppStorage("playgroundStyle") private var playgroundStyle: PlaygroundStyle = .sketch
 #endif
 #if os(iOS) && canImport(ImagePlayground)
@@ -572,7 +572,7 @@ struct ContentView: View {
     }
 
     func makeUIImage(from buffer: CVImageBuffer, maxDimension: CGFloat = 1024) -> UIImage? {
-        #if os(iOS)
+#if os(iOS)
         let ciImage = CIImage(cvPixelBuffer: buffer)
         let context = CIContext()
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
@@ -603,8 +603,9 @@ struct ContentView: View {
             Double(targetSize.height)
         ))
         return scaledImage
-        #endif
+#else
         return nil
+#endif
     }
 }
 

--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -35,6 +35,10 @@ enum DescriptionMode: String, CaseIterable, Identifiable {
 let shortPromptSuffix = "Output is very brief use maximum of 10 words."
 let longPromptSuffix = "Long and detailed description please."
 
+#if os(iOS)
+private let stableDiffusionLoadingMessage = "Loading Stable Diffusion pipeline. This may take a minute or so..."
+#endif
+
 struct ContentView: View {
     @State private var camera = CameraController()
     @StateObject private var model = FastVLMModel()
@@ -65,7 +69,6 @@ struct ContentView: View {
     @AppStorage("stableDiffusionGuidance") private var stableDiffusionGuidance: Double = StableDiffusionGuidancePreset.standard.rawValue
     @AppStorage("stableDiffusionPromptSuffix") private var stableDiffusionPromptSuffix: String = "photo, high quality, 8k"
     @StateObject private var stableDiffusionGenerator = StableDiffusionGenerator()
-    private static let stableDiffusionLoadingMessage = "Loading Stable Diffusion pipeline. This may take a minute or so..."
     @AppStorage("playgroundStyle") private var playgroundStyle: PlaygroundStyle = .sketch
 #endif
 #if os(iOS) && canImport(ImagePlayground)
@@ -147,7 +150,7 @@ struct ContentView: View {
                                     await generateLongDescription(frame)
                                     await MainActor.run {
                                         print("[Capture] Image description ready. Starting Stable Diffusion generation.")
-                                        self.generationStatus = Self.stableDiffusionLoadingMessage
+                                        self.generationStatus = stableDiffusionLoadingMessage
                                         startImageGeneration()
                                     }
                                 }
@@ -394,7 +397,7 @@ struct ContentView: View {
         }
         var initialStatus = "Preparing..."
         if provider == .stableDiffusion {
-            initialStatus = Self.stableDiffusionLoadingMessage
+            initialStatus = stableDiffusionLoadingMessage
         } else if provider == .imagePlayground {
             initialStatus = "Preparing Image Playground..."
         }
@@ -481,7 +484,7 @@ struct ContentView: View {
                             let logMessage: String
 
                             if step <= 0 {
-                                statusMessage = Self.stableDiffusionLoadingMessage
+                                statusMessage = stableDiffusionLoadingMessage
                                 logMessage = "[Generation] UI progress update: loading Stable Diffusion pipeline."
                             } else {
                                 let displayStep = min(max(step, 1), cappedTotal)

--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -477,14 +477,22 @@ struct ContentView: View {
                         guidanceScale: Float(self.stableDiffusionGuidance),
                         progress: { step, total in
                             let cappedTotal = max(total, 1)
+                            let statusMessage: String
+                            let logMessage: String
+
                             if step <= 0 {
-                                self.generationStatus = Self.stableDiffusionLoadingMessage
-                                print("[Generation] UI progress update: loading Stable Diffusion pipeline.")
+                                statusMessage = Self.stableDiffusionLoadingMessage
+                                logMessage = "[Generation] UI progress update: loading Stable Diffusion pipeline."
                             } else {
                                 let displayStep = min(max(step, 1), cappedTotal)
-                                self.generationStatus = "Step \(displayStep) of \(cappedTotal)"
-                                print("[Generation] UI progress update: step \(displayStep) of \(cappedTotal).")
+                                statusMessage = "Step \(displayStep) of \(cappedTotal)"
+                                logMessage = "[Generation] UI progress update: step \(displayStep) of \(cappedTotal)."
                             }
+
+                            Task { @MainActor in
+                                self.generationStatus = statusMessage
+                            }
+                            print(logMessage)
                         }
                     )
                     await MainActor.run {

--- a/app/GenAICam/FastVLMModel.swift
+++ b/app/GenAICam/FastVLMModel.swift
@@ -346,7 +346,31 @@ class FastVLMModel: ObservableObject {
         currentTask = task
         return task
     }
-    
+
+    @discardableResult
+    public func unloadForMemoryPressure(
+        reason: String = "Releasing FastVLM resources",
+        logWhenIdle: Bool = false
+    ) -> Bool {
+        currentTask?.cancel()
+        currentTask = nil
+        running = false
+        evaluationState = .idle
+
+        switch loadState {
+        case .idle:
+            if logWhenIdle {
+                print("[FastVLM] \(reason). No cached model to unload.")
+            }
+            return false
+        case .loaded:
+            print("[FastVLM] \(reason). Unloading cached model to free memory.")
+            loadState = .idle
+            modelInfo = "Unloaded to free memory"
+            return true
+        }
+    }
+
     public func cancel() {
         currentTask?.cancel()
         currentTask = nil

--- a/app/GenAICam/GenAICamApp.swift
+++ b/app/GenAICam/GenAICamApp.swift
@@ -8,7 +8,9 @@ import SwiftUI
 @main
 struct GenAICamApp: App {
     @State private var needsModelDownload = !(FastVLMModel.modelExists() && StableDiffusionModelManager.modelExists())
-    @State private var showPlaygroundWarning = false
+#if os(iOS)
+    @State private var isImagePlaygroundAvailable = false
+#endif
 
     var body: some Scene {
         WindowGroup {
@@ -16,23 +18,17 @@ struct GenAICamApp: App {
                 if needsModelDownload {
                     ModelDownloadView(needsModelDownload: $needsModelDownload)
                 } else {
+#if os(iOS)
+                    ContentView(isImagePlaygroundAvailable: isImagePlaygroundAvailable)
+#else
                     ContentView()
+#endif
                 }
             }
             .task {
 #if os(iOS)
                 await checkPlaygroundAvailability()
 #endif
-            }
-            .alert(
-                "Image Playground Unavailable",
-                isPresented: $showPlaygroundWarning
-            ) {
-                Button("OK", role: .cancel) {}
-            } message: {
-                Text(
-                    "Apple Image Playground is not installed or enabled. Image generation on device will not work; only image descriptions will be available."
-                )
             }
         }
     }
@@ -44,14 +40,12 @@ struct GenAICamApp: App {
         if #available(iOS 18.0, *) {
             let generator = PlaygroundImageGenerator()
             let available = await generator.isImagePlaygroundAvailable()
-            if !available {
-                showPlaygroundWarning = true
-            }
+            isImagePlaygroundAvailable = available
         } else {
-            showPlaygroundWarning = true
+            isImagePlaygroundAvailable = false
         }
 #else
-        showPlaygroundWarning = true
+        isImagePlaygroundAvailable = false
 #endif
 #endif
     }

--- a/app/GenAICam/Info.plist
+++ b/app/GenAICam/Info.plist
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>&quot;This app saves photos when requested by the user to the Photo Library&quot;</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>&quot;This app saves photos when requested by the user to the Photo Library&quot;</string>
+        <key>ITSAppUsesNonExemptEncryption</key>
+        <false/>
 </dict>
 </plist>

--- a/app/GenAICam/PhotoPreviewView.swift
+++ b/app/GenAICam/PhotoPreviewView.swift
@@ -23,6 +23,14 @@ struct PhotoPreviewView: View {
     @State private var showMore = false
     @State private var selection: ImageSelection = .original
     private let buttonSize: CGFloat = 80
+    private static let terminalStatusKeywords: [String] = [
+        "fail",
+        "error",
+        "cancel",
+        "require",
+        "unavailable",
+        "download"
+    ]
 
     enum ImageSelection: String, CaseIterable, Identifiable {
         case original
@@ -156,9 +164,7 @@ struct PhotoPreviewView: View {
                     if generatedImage == nil {
                         VStack(spacing: 16) {
                             if let status = generationStatus {
-                                ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                    .scaleEffect(1.2)
+                                statusIndicator(for: status)
                                 Text(status)
                                     .font(.headline)
                                     .foregroundColor(.white)
@@ -276,6 +282,26 @@ struct PhotoPreviewView: View {
                 shortDescription: shortDescription,
                 longDescription: longDescription
             )
+        }
+    }
+
+    private func isTerminalStatus(_ status: String) -> Bool {
+        let normalized = status.lowercased()
+        return Self.terminalStatusKeywords.contains { keyword in
+            normalized.contains(keyword)
+        }
+    }
+
+    @ViewBuilder
+    private func statusIndicator(for status: String) -> some View {
+        if isTerminalStatus(status) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 32, weight: .bold))
+                .foregroundColor(.yellow)
+        } else {
+            ProgressView()
+                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                .scaleEffect(1.2)
         }
     }
 

--- a/app/GenAICam/PhotoPreviewView.swift
+++ b/app/GenAICam/PhotoPreviewView.swift
@@ -107,16 +107,21 @@ struct PhotoPreviewView: View {
                                 Button("Recreate") { onRecreate() }
                             } else {
                                 ForEach(generationOptions) { option in
-                                    Button {
-                                        option.action()
-                                    } label: {
-                                        HStack {
-                                            Text(option.title)
-                                            if option.isSelected {
-                                                Spacer()
-                                                Image(systemName: "checkmark")
+                                    if option.isDivider {
+                                        Divider()
+                                    } else {
+                                        Button {
+                                            option.action()
+                                        } label: {
+                                            HStack {
+                                                Text(option.title)
+                                                if option.isSelected {
+                                                    Spacer()
+                                                    Image(systemName: "checkmark")
+                                                }
                                             }
                                         }
+                                        .disabled(!option.isEnabled)
                                     }
                                 }
                             }
@@ -300,7 +305,25 @@ struct GenerationOption: Identifiable {
     let id: String
     let title: String
     let isSelected: Bool
+    let isEnabled: Bool
+    let isDivider: Bool
     let action: () -> Void
+
+    init(
+        id: String,
+        title: String,
+        isSelected: Bool,
+        isEnabled: Bool = true,
+        isDivider: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.id = id
+        self.title = title
+        self.isSelected = isSelected
+        self.isEnabled = isEnabled
+        self.isDivider = isDivider
+        self.action = action
+    }
 }
 
 /// View modifier that applies the appropriate `onChange` variant depending on

--- a/app/GenAICam/SettingsView.swift
+++ b/app/GenAICam/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @Binding var isRealTime: Bool
     @Binding var showDescription: Bool
     @State private var showWelcome = false
+    let isImagePlaygroundAvailable: Bool
     
     private var appName: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String ?? "GenAICam"
@@ -42,7 +43,10 @@ struct SettingsView: View {
                 Section("Image Generation") {
                     Picker("Generator", selection: $provider) {
                         ForEach(ImageGeneratorProvider.allCases) { option in
-                            Text(option.title).tag(option)
+                            Text(option.title)
+                                .tag(option)
+                                .foregroundStyle(option == .imagePlayground && !isImagePlaygroundAvailable ? .secondary : .primary)
+                                .disabled(option == .imagePlayground && !isImagePlaygroundAvailable)
                         }
                     }
                     Text(provider.description)
@@ -50,11 +54,19 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                         .padding(.vertical, 4)
 
+                    if !isImagePlaygroundAvailable {
+                        Text("Image Playground is not available on this device.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+
                     switch provider {
                     case .imagePlayground:
-                        Picker("Style", selection: $style) {
-                            ForEach(PlaygroundStyle.allCases) { option in
-                                Text(option.rawValue.capitalized).tag(option)
+                        if isImagePlaygroundAvailable {
+                            Picker("Style", selection: $style) {
+                                ForEach(PlaygroundStyle.allCases) { option in
+                                    Text(option.rawValue.capitalized).tag(option)
+                                }
                             }
                         }
                     case .stableDiffusion:
@@ -104,6 +116,7 @@ struct SettingsView: View {
         stableDiffusionPromptSuffix: .constant("photo, high quality, 8k"),
         mode: .constant(.short),
         isRealTime: .constant(false),
-        showDescription: .constant(false)
+        showDescription: .constant(false),
+        isImagePlaygroundAvailable: true
     )
 }

--- a/app/GenAICam/StableDiffusion/Tokenizer/T5Tokenizer.swift
+++ b/app/GenAICam/StableDiffusion/Tokenizer/T5Tokenizer.swift
@@ -9,7 +9,7 @@ import Tokenizers
 public extension Config {
     /// Assumes the file is already present at local url.
     /// `fileURL` is a complete local file path for the given model
-    public init(fileURL: URL) throws  {
+    init(fileURL: URL) throws {
         let data = try Data(contentsOf: fileURL)
         let parsed = try JSONSerialization.jsonObject(with: data, options: [])
         guard var dictionary = parsed as? [String: Any] else { throw Hub.HubClientError.parse }

--- a/app/GenAICam/StableDiffusionGenerator.swift
+++ b/app/GenAICam/StableDiffusionGenerator.swift
@@ -50,7 +50,9 @@ final class StableDiffusionGenerator: ObservableObject {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.handleMemoryWarning()
+            Task { @MainActor [weak self] in
+                self?.handleMemoryWarning()
+            }
         }
 #else
         self.lowMemoryDevice = false

--- a/app/GenAICam/StableDiffusionGenerator.swift
+++ b/app/GenAICam/StableDiffusionGenerator.swift
@@ -30,9 +30,9 @@ final class StableDiffusionGenerator: ObservableObject {
     private var currentTask: Task<UIImage?, Error>?
     private var pipeline: StableDiffusionPipeline?
     private let lowMemoryDevice: Bool
-    #if os(iOS)
+#if os(iOS)
     private var memoryWarningObserver: NSObjectProtocol?
-    #endif
+#endif
 
     init() {
 #if os(iOS)
@@ -65,6 +65,10 @@ final class StableDiffusionGenerator: ObservableObject {
             NotificationCenter.default.removeObserver(observer)
         }
 #endif
+    }
+
+    var isLowMemoryDevice: Bool {
+        lowMemoryDevice
     }
 
     func generate(


### PR DESCRIPTION
## Summary
- detect low-memory iOS devices so we can log and apply memory-focused behavior
- disable the Stable Diffusion safety checker, skip pipeline prewarming, and avoid caching when memory is constrained
- pass the disable-safety flag into generation configuration to keep runtime logic consistent

## Testing
- Not run (iOS project cannot be built in this container)


------
https://chatgpt.com/codex/tasks/task_e_68cdd985cdc0832aaa23ec9d10656c62