### PR TITLE
Add option to start Stable Diffusion from captured photo

### DIFF
--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -61,6 +61,8 @@ struct ContentView: View {
     @State private var shortDescription: String = ""
     @State private var longDescription: String = ""
     @State private var showSettings: Bool = false
+    @State private var showSettingsAfterPreviewDismiss: Bool = false
+    @State private var reopenPreviewAfterSettings: Bool = false
 
     @State private var isRealTime: Bool = false
     @State private var showDescription: Bool = false
@@ -195,7 +197,7 @@ struct ContentView: View {
                         Spacer()
 
                         Button {
-                            showSettings = true
+                            presentSettings()
                         } label: {
                             Circle()
                                 .fill(Color.black.opacity(0.6))
@@ -269,6 +271,22 @@ struct ContentView: View {
                 showDescription: $showDescription,
                 isImagePlaygroundAvailable: isImagePlaygroundAvailable
             )
+        }
+        .onChange(of: showPreview) { _, isPresented in
+            if !isPresented && showSettingsAfterPreviewDismiss {
+                showSettingsAfterPreviewDismiss = false
+                showSettings = true
+            }
+        }
+        .onChange(of: showSettings) { _, isPresented in
+            if !isPresented {
+                if reopenPreviewAfterSettings, capturedImage != nil {
+                    reopenPreviewAfterSettings = false
+                    showPreview = true
+                } else {
+                    reopenPreviewAfterSettings = false
+                }
+            }
         }
 #if os(iOS)
         .onChange(of: isImagePlaygroundAvailable) { _, _ in
@@ -696,7 +714,7 @@ struct ContentView: View {
                     title: "Adjust in Settings…",
                     isSelected: false
                 ) {
-                    showSettings = true
+                    presentSettings(fromPreview: true)
                 }
             )
         }
@@ -748,6 +766,22 @@ struct ContentView: View {
         return scaledImage
 #else
         return nil
+#endif
+    }
+
+    private func presentSettings(fromPreview: Bool = false) {
+#if os(iOS)
+        if fromPreview && showPreview {
+            showSettingsAfterPreviewDismiss = true
+            reopenPreviewAfterSettings = true
+            showPreview = false
+        } else {
+            reopenPreviewAfterSettings = false
+            showSettingsAfterPreviewDismiss = false
+            showSettings = true
+        }
+#else
+        showSettings = true
 #endif
     }
 }

--- a/app/GenAICam/ContentView.swift
+++ b/app/GenAICam/ContentView.swift
@@ -552,7 +552,7 @@ struct ContentView: View {
                         stepCount: max(self.stableDiffusionStepCount, 1),
                         guidanceScale: Float(self.stableDiffusionGuidance),
                         startMode: startMode,
-                        strength: Float(self.stableDiffusionStrength),
+                        photoInfluence: Float(self.stableDiffusionStrength),
                         sourceImage: sourceImage,
                         progress: { step, total in
                             let cappedTotal = max(total, 1)
@@ -702,7 +702,7 @@ struct ContentView: View {
             items.append(
                 GenerationOption(
                     id: "strength-info",
-                    title: String(format: "Strength: %.2f", stableDiffusionStrength),
+                    title: String(format: "Photo influence: %.2f", stableDiffusionStrength),
                     isSelected: false,
                     isEnabled: false,
                     action: {}

--- a/app/GenAICam/ImageGenerationOptions.swift
+++ b/app/GenAICam/ImageGenerationOptions.swift
@@ -31,46 +31,6 @@ enum ImageGeneratorProvider: String, CaseIterable, Identifiable {
     }
 }
 
-/// Preset inference step options for Stable Diffusion generation.
-enum StableDiffusionStepPreset: Int, CaseIterable, Identifiable {
-    case fast = 15
-    case balanced = 25
-    case detailed = 35
-
-    var id: Int { rawValue }
-
-    var label: String {
-        switch self {
-        case .fast:
-            return "Fast (15 steps)"
-        case .balanced:
-            return "Balanced (25 steps)"
-        case .detailed:
-            return "Detailed (35 steps)"
-        }
-    }
-}
-
-/// Preset guidance scale options for Stable Diffusion generation.
-enum StableDiffusionGuidancePreset: Double, CaseIterable, Identifiable {
-    case subtle = 5.5
-    case standard = 7.5
-    case vibrant = 9.5
-
-    var id: Double { rawValue }
-
-    var label: String {
-        switch self {
-        case .subtle:
-            return "Subtle (5.5)"
-        case .standard:
-            return "Standard (7.5)"
-        case .vibrant:
-            return "Vibrant (9.5)"
-        }
-    }
-}
-
 /// Determines how Stable Diffusion should initialize the latent noise.
 enum StableDiffusionStartMode: String, CaseIterable, Identifiable {
     case noise

--- a/app/GenAICam/ImageGenerationOptions.swift
+++ b/app/GenAICam/ImageGenerationOptions.swift
@@ -70,3 +70,31 @@ enum StableDiffusionGuidancePreset: Double, CaseIterable, Identifiable {
         }
     }
 }
+
+/// Determines how Stable Diffusion should initialize the latent noise.
+enum StableDiffusionStartMode: String, CaseIterable, Identifiable {
+    case noise
+    case photo
+
+    var id: String { rawValue }
+
+    /// Short label used in pickers and menus.
+    var label: String {
+        switch self {
+        case .noise:
+            return "Noise"
+        case .photo:
+            return "Photo"
+        }
+    }
+
+    /// User-facing description of the mode.
+    var description: String {
+        switch self {
+        case .noise:
+            return "Start from random noise for a completely new image."
+        case .photo:
+            return "Use the captured photo as the starting point for image-to-image generation."
+        }
+    }
+}

--- a/app/GenAICam/Info.plist
+++ b/app/GenAICam/Info.plist
@@ -6,5 +6,13 @@
         <string>&quot;This app saves photos when requested by the user to the Photo Library&quot;</string>
         <key>ITSAppUsesNonExemptEncryption</key>
         <false/>
+        <key>UISupportedInterfaceOrientations</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+        </array>
+        <key>UISupportedInterfaceOrientations~ipad</key>
+        <array>
+                <string>UIInterfaceOrientationPortrait</string>
+        </array>
 </dict>
 </plist>

--- a/app/GenAICam/SettingsView.swift
+++ b/app/GenAICam/SettingsView.swift
@@ -111,17 +111,17 @@ struct SettingsView: View {
 
                         VStack(alignment: .leading, spacing: 8) {
                             HStack {
-                                Text("Photo strength")
+                                Text("Photo influence")
                                 Spacer()
                                 Text(String(format: "%.2f", stableDiffusionStrength))
                                     .foregroundStyle(.secondary)
                             }
                             Slider(
                                 value: $stableDiffusionStrength,
-                                in: 0.1...1.0,
+                                in: 0.0...1.0,
                                 step: 0.05
                             )
-                            Text("Controls how strongly the captured photo influences image-to-image results.")
+                            Text("Higher values keep the output closer to the captured photo, while lower values allow the model to diverge.")
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }

--- a/app/GenAICam/SettingsView.swift
+++ b/app/GenAICam/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @Binding var stableDiffusionStepCount: Int
     @Binding var stableDiffusionGuidance: Double
     @Binding var stableDiffusionPromptSuffix: String
+    @Binding var stableDiffusionStartMode: StableDiffusionStartMode
     @Binding var mode: DescriptionMode
     @Binding var isRealTime: Bool
     @Binding var showDescription: Bool
@@ -80,6 +81,16 @@ struct SettingsView: View {
                                 Text(preset.label).tag(preset.rawValue)
                             }
                         }
+                        Picker("Start from", selection: $stableDiffusionStartMode) {
+                            ForEach(StableDiffusionStartMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        Text(stableDiffusionStartMode.description)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .padding(.vertical, 4)
                         TextField("Additional prompt text", text: $stableDiffusionPromptSuffix)
 #if os(iOS)
                             .textInputAutocapitalization(.never)
@@ -114,6 +125,7 @@ struct SettingsView: View {
         stableDiffusionStepCount: .constant(StableDiffusionStepPreset.balanced.rawValue),
         stableDiffusionGuidance: .constant(StableDiffusionGuidancePreset.standard.rawValue),
         stableDiffusionPromptSuffix: .constant("photo, high quality, 8k"),
+        stableDiffusionStartMode: .constant(.noise),
         mode: .constant(.short),
         isRealTime: .constant(false),
         showDescription: .constant(false),

--- a/app/GenAICam/SettingsView.swift
+++ b/app/GenAICam/SettingsView.swift
@@ -11,6 +11,7 @@ struct SettingsView: View {
     @Binding var provider: ImageGeneratorProvider
     @Binding var stableDiffusionStepCount: Int
     @Binding var stableDiffusionGuidance: Double
+    @Binding var stableDiffusionStrength: Double
     @Binding var stableDiffusionPromptSuffix: String
     @Binding var stableDiffusionStartMode: StableDiffusionStartMode
     @Binding var mode: DescriptionMode
@@ -71,15 +72,58 @@ struct SettingsView: View {
                             }
                         }
                     case .stableDiffusion:
-                        Picker("Steps", selection: $stableDiffusionStepCount) {
-                            ForEach(StableDiffusionStepPreset.allCases) { preset in
-                                Text(preset.label).tag(preset.rawValue)
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Steps")
+                                Spacer()
+                                Text("\(stableDiffusionStepCount)")
+                                    .foregroundStyle(.secondary)
                             }
+                            Slider(
+                                value: Binding(
+                                    get: { Double(stableDiffusionStepCount) },
+                                    set: { stableDiffusionStepCount = Int($0.rounded()) }
+                                ),
+                                in: 10...50,
+                                step: 1
+                            )
+                            Text("More steps produce finer details but take longer to generate.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
                         }
-                        Picker("Guidance", selection: $stableDiffusionGuidance) {
-                            ForEach(StableDiffusionGuidancePreset.allCases) { preset in
-                                Text(preset.label).tag(preset.rawValue)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Guidance")
+                                Spacer()
+                                Text(String(format: "%.1f", stableDiffusionGuidance))
+                                    .foregroundStyle(.secondary)
                             }
+                            Slider(
+                                value: $stableDiffusionGuidance,
+                                in: 1...15,
+                                step: 0.5
+                            )
+                            Text("Higher guidance keeps results closer to the description while lower values allow more variety.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                Text("Photo strength")
+                                Spacer()
+                                Text(String(format: "%.2f", stableDiffusionStrength))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Slider(
+                                value: $stableDiffusionStrength,
+                                in: 0.1...1.0,
+                                step: 0.05
+                            )
+                            Text("Controls how strongly the captured photo influences image-to-image results.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
                         }
                         Picker("Start from", selection: $stableDiffusionStartMode) {
                             ForEach(StableDiffusionStartMode.allCases) { mode in
@@ -122,10 +166,11 @@ struct SettingsView: View {
     SettingsView(
         style: .constant(.sketch),
         provider: .constant(.stableDiffusion),
-        stableDiffusionStepCount: .constant(StableDiffusionStepPreset.balanced.rawValue),
-        stableDiffusionGuidance: .constant(StableDiffusionGuidancePreset.standard.rawValue),
+        stableDiffusionStepCount: .constant(25),
+        stableDiffusionGuidance: .constant(7.5),
+        stableDiffusionStrength: .constant(0.5),
         stableDiffusionPromptSuffix: .constant("photo, high quality, 8k"),
-        stableDiffusionStartMode: .constant(.noise),
+        stableDiffusionStartMode: .constant(.photo),
         mode: .constant(.short),
         isRealTime: .constant(false),
         showDescription: .constant(false),


### PR DESCRIPTION
## Summary
- add a Stable Diffusion start mode option that can be stored with app settings
- expose the start mode picker in settings and the preview context menu
- update the Stable Diffusion generator to optionally initialize from the captured photo

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cfe1768908832aa4f6166c8977cc27